### PR TITLE
Change jQuery.scrollTo asset folder case

### DIFF
--- a/JqueryScrollToAsset.php
+++ b/JqueryScrollToAsset.php
@@ -4,7 +4,7 @@ namespace uran1980\yii\assets\jQueryEssential;
 
 class JqueryScrollToAsset extends \yii\web\AssetBundle
 {
-    public $sourcePath = '@bower/jquery.scrollTo';
+    public $sourcePath = '@bower/jquery.scrollto';
     public $js = [
         'jquery.scrollTo.min.js',
     ];

--- a/composer.json
+++ b/composer.json
@@ -1,45 +1,43 @@
 {
-    "name": "uran1980/yii2-jquery-essential",
-    "description": "An Yii2 jQuery Essential assets component.",
-    "version": "0.0.6",
-    "type": "yii2-extension",
-    "keywords": [
-        "yii2-jquery-essential",
-        "yii2",
-        "assets",
-        "jQuery Essential Plugins",
-        "jQuery Cookie",
-        "jQuery MouseWheel",
-        "jQuery Scroll To",
-        "jQuery Easing"
-    ],
-    "homepage": "https://github.com/uran1980/yii2-jquery-essential",
-    "time": "2015-03-14 21:40",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Ivan Yakovlev",
-            "email": "uran1980@gmail.com",
-            "homepage": "https://github.com/uran1980",
-            "role": "Developer"
-        }
-    ],
-    "support": {
-        "issues": "https://github.com/uran1980/yii2-jquery-essential/issues",
-        "source": "https://github.com/uran1980/yii2-jquery-essential"
-    },
-    "require": {
-        "yiisoft/yii2": "~2",
-
-        "bower-asset/jquery-cookie": "*",
-        "bower-asset/jquery.easing": "*",
-        "bower-asset/jquery-mousewheel": "*",
-        "bower-asset/jquery-form": "*",
-        "bower-asset/jquery.scrollTo": "*"
-    },
-    "autoload": {
-        "psr-4": {
-            "uran1980\\yii\\assets\\jQueryEssential\\": ""
-        }
-    }
+	"name" : "uran1980/yii2-jquery-essential",
+	"description" : "An Yii2 jQuery Essential assets component.",
+	"version" : "0.0.7",
+	"type" : "yii2-extension",
+	"keywords" : [
+		"yii2-jquery-essential",
+		"yii2",
+		"assets",
+		"jQuery Essential Plugins",
+		"jQuery Cookie",
+		"jQuery MouseWheel",
+		"jQuery Scroll To",
+		"jQuery Easing"
+	],
+	"homepage" : "https://github.com/uran1980/yii2-jquery-essential",
+	"time" : "2015-03-14 21:40",
+	"license" : "MIT",
+	"authors" : [{
+			"name" : "Ivan Yakovlev",
+			"email" : "uran1980@gmail.com",
+			"homepage" : "https://github.com/uran1980",
+			"role" : "Developer"
+		}
+	],
+	"support" : {
+		"issues" : "https://github.com/uran1980/yii2-jquery-essential/issues",
+		"source" : "https://github.com/uran1980/yii2-jquery-essential"
+	},
+	"require" : {
+		"yiisoft/yii2" : "~2",
+		"bower-asset/jquery-cookie" : "*",
+		"bower-asset/jquery.easing" : "*",
+		"bower-asset/jquery-mousewheel" : "*",
+		"bower-asset/jquery-form" : "*",
+		"bower-asset/jquery.scrollTo" : "*"
+	},
+	"autoload" : {
+		"psr-4" : {
+			"uran1980\\yii\\assets\\jQueryEssential\\" : ""
+		}
+	}
 }


### PR DESCRIPTION
As Composer normalizes to all-lowercase dependencies names, the folder of assets are also all-lowercase.

This just changes the path declared in the asset class for it to work with the currently resolved project jquery.scrollTo, which is https://github.com/flesler/jquery.scrollTo.git.

If this is not the target dependency, please take a look at https://github.com/yiisoft/yii2/issues/6718 to have composer's fxp/composer-asset-plugin to resolve to the correct one.